### PR TITLE
Buffer of into stream

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1014,6 +1014,7 @@ impl Link {
 
 #[cfg(test)]
 mod tests {
+    use crate::alloc::vec::Vec;
     #[cfg(feature = "std")]
     use crate::StreamBuf;
     use crate::{decode, BitOrder};
@@ -1023,7 +1024,7 @@ mod tests {
             env!("CARGO_MANIFEST_DIR"),
             "/benches/binary-8-msb.lzw"
         ));
-        return FILE.to_owned();
+        return Vec::from(FILE);
     }
 
     #[test]

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "std")]
 use crate::error::StreamResult;
 use crate::error::{BufferResult, LzwError, LzwStatus};
-use crate::{BitOrder, Code, MAX_CODESIZE, MAX_ENTRIES, STREAM_BUF_SIZE};
+use crate::{BitOrder, Code, StreamBuf, MAX_CODESIZE, MAX_ENTRIES, STREAM_BUF_SIZE};
 
 use crate::alloc::{boxed::Box, vec, vec::Vec};
 #[cfg(feature = "std")]
@@ -27,11 +27,6 @@ pub struct IntoStream<'d, W> {
     writer: W,
     buffer: Option<StreamBuf<'d>>,
     default_size: usize,
-}
-
-enum StreamBuf<'d> {
-    Borrowed(&'d mut [u8]),
-    Owned(Vec<u8>),
 }
 
 trait Stateful {
@@ -1020,7 +1015,7 @@ impl Link {
 #[cfg(test)]
 mod tests {
     #[cfg(feature = "std")]
-    use super::StreamBuf;
+    use crate::StreamBuf;
     use crate::{decode, BitOrder};
 
     fn make_encoded() -> Vec<u8> {

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -761,6 +761,7 @@ impl From<FullKey> for CompressedKey {
 #[cfg(test)]
 mod tests {
     use super::{BitOrder, Encoder, LzwError, LzwStatus};
+    use crate::alloc::vec::Vec;
     use crate::decode::Decoder;
     #[cfg(feature = "std")]
     use crate::StreamBuf;
@@ -817,7 +818,7 @@ mod tests {
     fn make_decoded() -> Vec<u8> {
         const FILE: &'static [u8] =
             include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.lock"));
-        return FILE.to_owned();
+        return Vec::from(FILE);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,13 @@ pub(crate) const MAX_ENTRIES: usize = 1 << MAX_CODESIZE as usize;
 /// Alias for a LZW code point
 pub(crate) type Code = u16;
 
+/// A default buffer size for encoding/decoding buffer.
+///
+/// Note that this is larger than the default size for buffers (usually 4K) since each code word
+/// can expand to multiple bytes. Expanding one buffer would yield multiple and require a costly
+/// break in the decoding loop. Note that the decoded size can be up to quadratic in code block.
+pub(crate) const STREAM_BUF_SIZE: usize = 1 << 24;
+
 /// The order of bits in bytes.
 pub enum BitOrder {
     /// The most significant bit is processed first.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,13 @@ pub enum BitOrder {
     Lsb,
 }
 
+/// An owned or borrowed buffer for stream operations.
+#[cfg(feature = "alloc")]
+pub(crate) enum StreamBuf<'d> {
+    Borrowed(&'d mut [u8]),
+    Owned(crate::alloc::vec::Vec<u8>),
+}
+
 #[cfg(feature = "alloc")]
 pub mod decode;
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
Avoid reallocating buffers and give the caller control over the allocation size, or even allow substituting a buffer already allocated and borrowed to the stream coder.

Closes: #10 