### PR TITLE
Roundtrip testing

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,7 @@ jobs:
         cargo build --verbose --no-default-features --features "$FEATURES"
     - name: test
       run: >
-        cargo test --tests --benches --no-default-features --features "$FEATURES"
+        cargo test --tests --benches --no-default-features --features "$FEATURES" --release
       if: ${{ matrix.rust != '1.34.2' }}
       env:
         FEATURES: ${{ matrix.features }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,7 @@ required-features = ["std"]
 [[example]]
 name = "lzw-decompress"
 required-features = ["std"]
+
+[[test]]
+name = "roundtrip"
+required-features = ["std"]

--- a/fuzz/fuzz_targets/roundtrip.rs
+++ b/fuzz/fuzz_targets/roundtrip.rs
@@ -3,14 +3,13 @@ use libfuzzer_sys::fuzz_target;
 use weezl::{BitOrder, encode, decode};
 
 fuzz_target!(|data: &[u8]| {
-    let mut encoder = encode::Encoder::new(BitOrder::Msb, 8);
+    let mut encoder = encode::Encoder::with_tiff_size_switch(BitOrder::Msb, 8);
     let mut buffer = Vec::with_capacity(2*data.len() + 40);
     let _ = encoder.into_stream(&mut buffer).encode_all(data);
 
-    let mut decoder = decode::Decoder::new(BitOrder::Msb, 8);
+    let mut decoder = decode::Decoder::with_tiff_size_switch(BitOrder::Msb, 8);
     let mut compare = vec![];
     let result = decoder.into_stream(&mut compare).decode_all(buffer.as_slice());
-    // dbg!(buffer.as_slice());
-    // dbg!(&result.status);
     assert!(result.status.is_ok(), "{:?}", result.status);
+    assert_eq!(data, &*compare);
 });

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1033,9 +1033,9 @@ impl Link {
 #[cfg(test)]
 mod tests {
     use crate::alloc::vec::Vec;
-    use crate::{decode::Decoder, BitOrder};
     #[cfg(feature = "std")]
     use crate::StreamBuf;
+    use crate::{decode::Decoder, BitOrder};
 
     #[test]
     #[should_panic]

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -127,8 +127,13 @@ impl Decoder {
     /// The algorithm for dynamically increasing the code symbol bit width is compatible with the
     /// original specification. In particular you will need to specify an `Lsb` bit oder to decode
     /// the data portion of a compressed `gif` image.
+    ///
+    /// # Panics
+    ///
+    /// The `size` needs to be in the interval `2..=12`.
     pub fn new(order: BitOrder, size: u8) -> Self {
         type Boxed = Box<dyn Stateful + Send + 'static>;
+        super::assert_code_size(size);
         let state = match order {
             BitOrder::Lsb => Box::new(DecodeState::<LsbBuffer>::new(size)) as Boxed,
             BitOrder::Msb => Box::new(DecodeState::<MsbBuffer>::new(size)) as Boxed,
@@ -142,8 +147,13 @@ impl Decoder {
     /// The algorithm for dynamically increasing the code symbol bit width is compatible with the
     /// TIFF specification, which is a misinterpretation of the original algorithm for increasing
     /// the code size. It switches one symbol sooner.
+    ///
+    /// # Panics
+    ///
+    /// The `size` needs to be in the interval `2..=12`.
     pub fn with_tiff_size_switch(order: BitOrder, size: u8) -> Self {
         type Boxed = Box<dyn Stateful + Send + 'static>;
+        super::assert_code_size(size);
         let state = match order {
             BitOrder::Lsb => {
                 let mut state = Box::new(DecodeState::<LsbBuffer>::new(size));
@@ -1023,9 +1033,21 @@ impl Link {
 #[cfg(test)]
 mod tests {
     use crate::alloc::vec::Vec;
+    use crate::{decode::Decoder, BitOrder};
     #[cfg(feature = "std")]
     use crate::StreamBuf;
-    use crate::{decode, BitOrder};
+
+    #[test]
+    #[should_panic]
+    fn invalid_code_size_low() {
+        let _ = Decoder::new(BitOrder::Msb, 1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn invalid_code_size_high() {
+        let _ = Decoder::new(BitOrder::Msb, 14);
+    }
 
     fn make_encoded() -> Vec<u8> {
         const FILE: &'static [u8] = include_bytes!(concat!(
@@ -1039,7 +1061,7 @@ mod tests {
     #[cfg(feature = "std")]
     fn into_stream_buffer_no_alloc() {
         let encoded = make_encoded();
-        let mut decoder = decode::Decoder::new(BitOrder::Msb, 8);
+        let mut decoder = Decoder::new(BitOrder::Msb, 8);
 
         let mut output = vec![];
         let mut buffer = [0; 512];
@@ -1071,7 +1093,7 @@ mod tests {
         }
 
         let encoded = make_encoded();
-        let mut decoder = decode::Decoder::new(BitOrder::Msb, 8);
+        let mut decoder = Decoder::new(BitOrder::Msb, 8);
 
         let mut output = vec![];
         let mut istream = decoder.into_stream(WriteTap(&mut output));
@@ -1089,7 +1111,7 @@ mod tests {
     #[cfg(feature = "std")]
     fn reset() {
         let encoded = make_encoded();
-        let mut decoder = decode::Decoder::new(BitOrder::Msb, 8);
+        let mut decoder = Decoder::new(BitOrder::Msb, 8);
         let mut reference = None;
 
         for _ in 0..2 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@ pub(crate) type Code = u16;
 pub(crate) const STREAM_BUF_SIZE: usize = 1 << 24;
 
 /// The order of bits in bytes.
+#[derive(Clone, Copy)]
 pub enum BitOrder {
     /// The most significant bit is processed first.
     Msb,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,11 @@ pub(crate) enum StreamBuf<'d> {
 #[cold]
 fn assert_code_size(size: u8) {
     assert!(size >= 2, "Minimum code size 2 required, got {}", size);
-    assert!(size <= MAX_CODESIZE, "Maximum code size 12 required, got {}", size);
+    assert!(
+        size <= MAX_CODESIZE,
+        "Maximum code size 12 required, got {}",
+        size
+    );
 }
 
 #[cfg(feature = "alloc")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,12 @@ pub(crate) enum StreamBuf<'d> {
     Owned(crate::alloc::vec::Vec<u8>),
 }
 
+#[cold]
+fn assert_code_size(size: u8) {
+    assert!(size >= 2, "Minimum code size 2 required, got {}", size);
+    assert!(size <= MAX_CODESIZE, "Maximum code size 12 required, got {}", size);
+}
+
 #[cfg(feature = "alloc")]
 pub mod decode;
 #[cfg(feature = "alloc")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ pub(crate) type Code = u16;
 pub(crate) const STREAM_BUF_SIZE: usize = 1 << 24;
 
 /// The order of bits in bytes.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum BitOrder {
     /// The most significant bit is processed first.
     Msb,

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -1,5 +1,5 @@
-use weezl::{BitOrder, encode, decode};
 use std::{env, fs};
+use weezl::{decode, encode, BitOrder};
 
 #[derive(Clone, Copy)]
 enum Flavor {
@@ -16,7 +16,11 @@ fn roundtrip_all() {
     for &flavor in &[Flavor::Gif, Flavor::Tiff] {
         for &bit_order in &[BitOrder::Lsb, BitOrder::Msb] {
             for bit_width in (2..8).rev() {
-                let data: Vec<_> = data.iter().copied().map(|b| b & ((1 << bit_width) - 1)).collect();
+                let data: Vec<_> = data
+                    .iter()
+                    .copied()
+                    .map(|b| b & ((1 << bit_width) - 1))
+                    .collect();
 
                 assert_roundtrips(&*data, flavor, bit_width, bit_order);
             }
@@ -24,27 +28,36 @@ fn roundtrip_all() {
     }
 }
 
-fn assert_roundtrips(
-    data: &[u8],
-    flavor: Flavor,
-    bit_width: u8,
-    bit_order: BitOrder,
-) {
-    let (c, d): (fn(BitOrder, u8) -> encode::Encoder, fn(BitOrder, u8) -> decode::Decoder) = match flavor {
+fn assert_roundtrips(data: &[u8], flavor: Flavor, bit_width: u8, bit_order: BitOrder) {
+    let (c, d): (
+        fn(BitOrder, u8) -> encode::Encoder,
+        fn(BitOrder, u8) -> decode::Decoder,
+    ) = match flavor {
         Flavor::Gif => (encode::Encoder::new, decode::Decoder::new),
-        Flavor::Tiff => (encode::Encoder::with_tiff_size_switch, decode::Decoder::with_tiff_size_switch),
+        Flavor::Tiff => (
+            encode::Encoder::with_tiff_size_switch,
+            decode::Decoder::with_tiff_size_switch,
+        ),
     };
     eprintln!("Roundtrip test {:?} {}", bit_order, bit_width);
     let mut encoder = c(bit_order, bit_width);
-    let mut buffer = Vec::with_capacity(2*data.len() + 40);
+    let mut buffer = Vec::with_capacity(2 * data.len() + 40);
     let _ = encoder.into_stream(&mut buffer).encode_all(data);
     fs::write("/tmp/encoded", buffer.as_slice()).unwrap();
 
     let mut decoder = d(bit_order, bit_width);
     let mut compare = vec![];
-    let result = decoder.into_stream(&mut compare).decode_all(buffer.as_slice());
+    let result = decoder
+        .into_stream(&mut compare)
+        .decode_all(buffer.as_slice());
     fs::write("/tmp/decoded0", data).unwrap();
     fs::write("/tmp/decoded1", compare.as_slice()).unwrap();
-    assert!(result.status.is_ok(), "{:?}, {}, {:?}", bit_order, bit_width, result.status);
+    assert!(
+        result.status.is_ok(),
+        "{:?}, {}, {:?}",
+        bit_order,
+        bit_width,
+        result.status
+    );
     assert!(data == &*compare, "{:?}, {}", bit_order, bit_width);
 }

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -1,33 +1,46 @@
 use weezl::{BitOrder, encode, decode};
 use std::{env, fs};
 
+#[derive(Clone, Copy)]
+enum Flavor {
+    Gif,
+    Tiff,
+}
+
 #[test]
 fn roundtrip_all() {
     let file = env::args().next().unwrap();
     dbg!(&file);
-    let data = fs::read("Cargo.lock").unwrap();
+    let data = fs::read(file).unwrap();
 
-    for bit_order in &[BitOrder::Lsb, BitOrder::Msb] {
-        for bit_width in (2..8).rev() {
-            let data: Vec<_> = data.iter().copied().map(|b| b & ((1 << bit_width) - 1)).collect();
+    for &flavor in &[Flavor::Gif, Flavor::Tiff] {
+        for &bit_order in &[BitOrder::Lsb, BitOrder::Msb] {
+            for bit_width in (2..8).rev() {
+                let data: Vec<_> = data.iter().copied().map(|b| b & ((1 << bit_width) - 1)).collect();
 
-            assert_roundtrips(&*data, bit_width, *bit_order);
+                assert_roundtrips(&*data, flavor, bit_width, bit_order);
+            }
         }
     }
 }
 
 fn assert_roundtrips(
     data: &[u8],
+    flavor: Flavor,
     bit_width: u8,
     bit_order: BitOrder,
 ) {
+    let (c, d): (fn(BitOrder, u8) -> encode::Encoder, fn(BitOrder, u8) -> decode::Decoder) = match flavor {
+        Flavor::Gif => (encode::Encoder::new, decode::Decoder::new),
+        Flavor::Tiff => (encode::Encoder::with_tiff_size_switch, decode::Decoder::with_tiff_size_switch),
+    };
     eprintln!("Roundtrip test {:?} {}", bit_order, bit_width);
-    let mut encoder = encode::Encoder::with_tiff_size_switch(bit_order, bit_width);
+    let mut encoder = c(bit_order, bit_width);
     let mut buffer = Vec::with_capacity(2*data.len() + 40);
     let _ = encoder.into_stream(&mut buffer).encode_all(data);
     fs::write("/tmp/encoded", buffer.as_slice()).unwrap();
 
-    let mut decoder = decode::Decoder::with_tiff_size_switch(bit_order, bit_width);
+    let mut decoder = d(bit_order, bit_width);
     let mut compare = vec![];
     let result = decoder.into_stream(&mut compare).decode_all(buffer.as_slice());
     fs::write("/tmp/decoded0", data).unwrap();

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -1,7 +1,7 @@
 use std::{env, fs};
 use weezl::{decode, encode, BitOrder};
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 enum Flavor {
     Gif,
     Tiff,
@@ -10,7 +10,6 @@ enum Flavor {
 #[test]
 fn roundtrip_all() {
     let file = env::args().next().unwrap();
-    dbg!(&file);
     let data = fs::read(file).unwrap();
 
     for &flavor in &[Flavor::Gif, Flavor::Tiff] {
@@ -22,6 +21,7 @@ fn roundtrip_all() {
                     .map(|b| b & ((1 << bit_width) - 1))
                     .collect();
 
+                println!("Roundtrip test {:?} {:?} {}", flavor, bit_order, bit_width);
                 assert_roundtrips(&*data, flavor, bit_width, bit_order);
             }
         }
@@ -39,19 +39,15 @@ fn assert_roundtrips(data: &[u8], flavor: Flavor, bit_width: u8, bit_order: BitO
             decode::Decoder::with_tiff_size_switch,
         ),
     };
-    eprintln!("Roundtrip test {:?} {}", bit_order, bit_width);
     let mut encoder = c(bit_order, bit_width);
     let mut buffer = Vec::with_capacity(2 * data.len() + 40);
     let _ = encoder.into_stream(&mut buffer).encode_all(data);
-    fs::write("/tmp/encoded", buffer.as_slice()).unwrap();
 
     let mut decoder = d(bit_order, bit_width);
     let mut compare = vec![];
     let result = decoder
         .into_stream(&mut compare)
         .decode_all(buffer.as_slice());
-    fs::write("/tmp/decoded0", data).unwrap();
-    fs::write("/tmp/decoded1", compare.as_slice()).unwrap();
     assert!(
         result.status.is_ok(),
         "{:?}, {}, {:?}",

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -3,10 +3,12 @@ use std::{env, fs};
 
 #[test]
 fn roundtrip_all() {
-    let data = fs::read(env::args().next().unwrap()).unwrap();
+    let file = env::args().next().unwrap();
+    dbg!(&file);
+    let data = fs::read("Cargo.lock").unwrap();
 
-    for bit_order in &[BitOrder::Msb, BitOrder::Lsb] {
-        for bit_width in 1..8 {
+    for bit_order in &[BitOrder::Lsb, BitOrder::Msb] {
+        for bit_width in (2..8).rev() {
             let data: Vec<_> = data.iter().copied().map(|b| b & ((1 << bit_width) - 1)).collect();
 
             assert_roundtrips(&*data, bit_width, *bit_order);
@@ -19,13 +21,17 @@ fn assert_roundtrips(
     bit_width: u8,
     bit_order: BitOrder,
 ) {
+    eprintln!("Roundtrip test {:?} {}", bit_order, bit_width);
     let mut encoder = encode::Encoder::with_tiff_size_switch(bit_order, bit_width);
     let mut buffer = Vec::with_capacity(2*data.len() + 40);
     let _ = encoder.into_stream(&mut buffer).encode_all(data);
+    fs::write("/tmp/encoded", buffer.as_slice()).unwrap();
 
     let mut decoder = decode::Decoder::with_tiff_size_switch(bit_order, bit_width);
     let mut compare = vec![];
     let result = decoder.into_stream(&mut compare).decode_all(buffer.as_slice());
-    assert!(result.status.is_ok(), "{:?}", result.status);
-    assert_eq!(data, &*compare);
+    fs::write("/tmp/decoded0", data).unwrap();
+    fs::write("/tmp/decoded1", compare.as_slice()).unwrap();
+    assert!(result.status.is_ok(), "{:?}, {}, {:?}", bit_order, bit_width, result.status);
+    assert!(data == &*compare, "{:?}, {}", bit_order, bit_width);
 }

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -1,0 +1,31 @@
+use weezl::{BitOrder, encode, decode};
+use std::{env, fs};
+
+#[test]
+fn roundtrip_all() {
+    let data = fs::read(env::args().next().unwrap()).unwrap();
+
+    for bit_order in &[BitOrder::Msb, BitOrder::Lsb] {
+        for bit_width in 1..8 {
+            let data: Vec<_> = data.iter().copied().map(|b| b & ((1 << bit_width) - 1)).collect();
+
+            assert_roundtrips(&*data, bit_width, *bit_order);
+        }
+    }
+}
+
+fn assert_roundtrips(
+    data: &[u8],
+    bit_width: u8,
+    bit_order: BitOrder,
+) {
+    let mut encoder = encode::Encoder::with_tiff_size_switch(bit_order, bit_width);
+    let mut buffer = Vec::with_capacity(2*data.len() + 40);
+    let _ = encoder.into_stream(&mut buffer).encode_all(data);
+
+    let mut decoder = decode::Decoder::with_tiff_size_switch(bit_order, bit_width);
+    let mut compare = vec![];
+    let result = decoder.into_stream(&mut compare).decode_all(buffer.as_slice());
+    assert!(result.status.is_ok(), "{:?}", result.status);
+    assert_eq!(data, &*compare);
+}


### PR DESCRIPTION
A full coverage of roundtrip tests for encoder and decoder. Fixes a bug in the encoder that cause it to lose clear codes and subsequently of course complete garbage data including incorrect end codes.

Closes: #18