### PR TITLE
Add into_vec for simple in-memory coding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,12 +67,16 @@ name = "lzw-decompress"
 required-features = ["std"]
 
 [[test]]
+name = "async"
+required-features = ["async", "std"]
+
+[[test]]
 name = "roundtrip"
 required-features = ["std"]
 
 [[test]]
-name = "async"
-required-features = ["async", "std"]
+name = "roundtrip_vec"
+required-features = ["alloc"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,3 +73,6 @@ required-features = ["std"]
 [[test]]
 name = "async"
 required-features = ["async", "std"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -47,6 +47,16 @@ pub struct IntoAsync<'d, W> {
     default_size: usize,
 }
 
+/// A decoding sink into a vector.
+///
+/// See [`Decoder::into_vec`] on how to create this type.
+///
+/// [`Decoder::into_vec`]: struct.Decoder.html#method.into_vec
+pub struct IntoVec<'d> {
+    decoder: &'d mut Decoder,
+    vector: &'d mut Vec<u8>,
+}
+
 trait Stateful {
     fn advance(&mut self, inp: &[u8], out: &mut [u8]) -> BufferResult;
     fn has_ended(&self) -> bool;
@@ -223,6 +233,17 @@ impl Decoder {
         }
     }
 
+    /// Construct a decoder into a vector.
+    ///
+    /// All decoded data is appended and the vector is __not__ cleared.
+    ///
+    /// Compared to `into_stream` this interface allows a high-level access to decoding without
+    /// requires the `std`-feature. Also, it can make full use of the extra buffer control that the
+    /// special target exposes.
+    pub fn into_vec<'lt>(&'lt mut self, vec: &'lt mut Vec<u8>) -> IntoVec<'lt> {
+        IntoVec { decoder: self, vector: vec }
+    }
+
     /// Check if the decoding has finished.
     ///
     /// No more output is produced beyond the end code that marked the finish of the stream. The
@@ -386,6 +407,93 @@ impl<'d, W: Write> IntoStream<'d, W> {
             bytes_written,
             status,
         }
+    }
+}
+
+impl IntoVec<'_> {
+    /// Decode data from a reader.
+    ///
+    /// This will read data until the stream is empty or an end marker is reached.
+    pub fn decode(&mut self, read:  &[u8]) -> BufferResult {
+        self.decode_part(read, false)
+    }
+
+    /// Decode data from a reader, requiring an end marker.
+    pub fn decode_all(mut self, read: &[u8]) -> BufferResult {
+        self.decode_part(read, true)
+    }
+
+    fn grab_buffer(&mut self) -> (&mut [u8], &mut Decoder) {
+        const CHUNK_SIZE: usize = 1 << 12;
+        let decoder = &mut self.decoder;
+        let length = self.vector.len();
+
+        // Use the vector to do overflow checks and w/e.
+        self.vector.reserve(CHUNK_SIZE);
+        self.vector.resize(length + CHUNK_SIZE, 0u8);
+
+        (&mut self.vector[length..], decoder)
+    }
+
+    fn decode_part(&mut self, part: &[u8], must_finish: bool) -> BufferResult {
+        let mut result = BufferResult {
+            consumed_in: 0,
+            consumed_out: 0,
+            status: Ok(LzwStatus::Ok),
+        };
+
+        enum Progress {
+            Ok,
+            Done,
+        }
+
+        // Converting to mutable refs to move into the `once` closure.
+        let read_bytes = &mut result.consumed_in;
+        let write_bytes = &mut result.consumed_out;
+        let mut data = part;
+
+        // A 64 MB buffer is quite large but should get alloc_zeroed.
+        // Note that the decoded size can be up to quadratic in code block.
+        let once = move || {
+            // Grab a new output buffer.
+            let (outbuf, decoder) = self.grab_buffer();
+
+            // Decode as much of the buffer as fits.
+            let result = decoder.decode_bytes(data, &mut outbuf[..]);
+            // Do the bookkeeping and consume the buffer.
+            *read_bytes += result.consumed_in;
+            *write_bytes += result.consumed_out;
+            data = &data[result.consumed_in..];
+
+            let unfilled = outbuf.len() - result.consumed_out;
+            let filled = self.vector.len() - unfilled;
+            self.vector.truncate(filled);
+
+            // Handle the status in the result.
+            match result.status {
+                Err(err) => Err(err),
+                Ok(LzwStatus::NoProgress) if must_finish => Err(LzwError::InvalidCode),
+                Ok(LzwStatus::NoProgress) | Ok(LzwStatus::Done) => Ok(Progress::Done),
+                Ok(LzwStatus::Ok) => Ok(Progress::Ok),
+            }
+        };
+
+        // Decode chunks of input data until we're done.
+        let status: Result<(), _> = core::iter::repeat_with(once)
+            // scan+fuse can be replaced with map_while
+            .scan((), |(), result| match result {
+                Ok(Progress::Ok) => Some(Ok(())),
+                Err(err) => Some(Err(err)),
+                Ok(Progress::Done) => None,
+            })
+            .fuse()
+            .collect();
+
+        if let Err(err) = status {
+            result.status = Err(err);
+        }
+
+        result
     }
 }
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -285,7 +285,10 @@ impl Decoder {
     /// requires the `std`-feature. Also, it can make full use of the extra buffer control that the
     /// special target exposes.
     pub fn into_vec<'lt>(&'lt mut self, vec: &'lt mut Vec<u8>) -> IntoVec<'lt> {
-        IntoVec { decoder: self, vector: vec }
+        IntoVec {
+            decoder: self,
+            vector: vec,
+        }
     }
 
     /// Check if the decoding has finished.
@@ -458,7 +461,7 @@ impl IntoVec<'_> {
     /// Decode data from a slice.
     ///
     /// This will read data until the slice is empty or an end marker is reached.
-    pub fn decode(&mut self, read:  &[u8]) -> VectorResult {
+    pub fn decode(&mut self, read: &[u8]) -> VectorResult {
         self.decode_part(read, false)
     }
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -211,6 +211,34 @@ impl Decoder {
         self.state.advance(inp, out)
     }
 
+    /// Decode a single chunk of lzw encoded data.
+    ///
+    /// This method requires the data to contain an end marker, and returns an error otherwise.
+    ///
+    /// This is a convenience wrapper around [`into_vec`]. Use the `into_vec` adapter to customize
+    /// buffer size, to supply an existing vector, to control whether an end marker is required, or
+    /// to preserve partial data in the case of a decoding error.
+    ///
+    /// [`into_vec`]: #into_vec
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use weezl::{BitOrder, decode::Decoder};
+    ///
+    /// // Encoded that was created with an encoder.
+    /// let data = b"\x80\x04\x81\x94l\x1b\x06\xf0\xb0 \x1d\xc6\xf1\xc8l\x19 \x10";
+    /// let decoded = Decoder::new(BitOrder::Msb, 9)
+    ///     .decode(data)
+    ///     .unwrap();
+    /// assert_eq!(decoded, b"Hello, world");
+    /// ```
+    pub fn decode(&mut self, data: &[u8]) -> Result<Vec<u8>, LzwError> {
+        let mut output = vec![];
+        self.into_vec(&mut output).decode_all(data).status?;
+        Ok(output)
+    }
+
     /// Construct a decoder into a writer.
     #[cfg(feature = "std")]
     pub fn into_stream<W: Write>(&mut self, writer: W) -> IntoStream<'_, W> {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -13,6 +13,22 @@ use std::io::{self, BufRead, Write};
 /// The same structure can be utilized with streams as well as your own buffers and driver logic.
 /// It may even be possible to mix them if you are sufficiently careful not to lose or skip any
 /// already decode data in the process.
+///
+/// This is a sans-IO implementation, meaning that it only contains the state of the decoder and
+/// the caller will provide buffers for input and output data when calling the basic
+/// [`decode_bytes`] method. Nevertheless, a number of _adapters_ are provided in the `into_*`
+/// methods for decoding with a particular style of common IO.
+///
+/// * [`decode`] for decoding once without any IO-loop.
+/// * [`into_async`] for decoding with the `futures` traits for asynchronous IO.
+/// * [`into_stream`] for decoding with the standard `io` traits.
+/// * [`into_vec`] for in-memory decoding.
+///
+/// [`decode_bytes`]: #method.decode_bytes
+/// [`decode`]: #method.decode
+/// [`into_async`]: #method.into_async
+/// [`into_stream`]: #method.into_stream
+/// [`into_vec`]: #method.into_vec
 pub struct Decoder {
     state: Box<dyn Stateful + Send + 'static>,
 }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1,7 +1,7 @@
 //! A module for all decoding needs.
 #[cfg(feature = "std")]
 use crate::error::StreamResult;
-use crate::error::{BufferResult, LzwError, LzwStatus};
+use crate::error::{BufferResult, LzwError, LzwStatus, VectorResult};
 use crate::{BitOrder, Code, StreamBuf, MAX_CODESIZE, MAX_ENTRIES, STREAM_BUF_SIZE};
 
 use crate::alloc::{boxed::Box, vec, vec::Vec};
@@ -414,12 +414,12 @@ impl IntoVec<'_> {
     /// Decode data from a reader.
     ///
     /// This will read data until the stream is empty or an end marker is reached.
-    pub fn decode(&mut self, read:  &[u8]) -> BufferResult {
+    pub fn decode(&mut self, read:  &[u8]) -> VectorResult {
         self.decode_part(read, false)
     }
 
     /// Decode data from a reader, requiring an end marker.
-    pub fn decode_all(mut self, read: &[u8]) -> BufferResult {
+    pub fn decode_all(mut self, read: &[u8]) -> VectorResult {
         self.decode_part(read, true)
     }
 
@@ -435,8 +435,8 @@ impl IntoVec<'_> {
         (&mut self.vector[length..], decoder)
     }
 
-    fn decode_part(&mut self, part: &[u8], must_finish: bool) -> BufferResult {
-        let mut result = BufferResult {
+    fn decode_part(&mut self, part: &[u8], must_finish: bool) -> VectorResult {
+        let mut result = VectorResult {
             consumed_in: 0,
             consumed_out: 0,
             status: Ok(LzwStatus::Ok),

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -411,14 +411,14 @@ impl<'d, W: Write> IntoStream<'d, W> {
 }
 
 impl IntoVec<'_> {
-    /// Decode data from a reader.
+    /// Decode data from a slice.
     ///
-    /// This will read data until the stream is empty or an end marker is reached.
+    /// This will read data until the slice is empty or an end marker is reached.
     pub fn decode(&mut self, read:  &[u8]) -> VectorResult {
         self.decode_part(read, false)
     }
 
-    /// Decode data from a reader, requiring an end marker.
+    /// Decode data from a slice, requiring an end marker.
     pub fn decode_all(mut self, read: &[u8]) -> VectorResult {
         self.decode_part(read, true)
     }
@@ -430,6 +430,7 @@ impl IntoVec<'_> {
 
         // Use the vector to do overflow checks and w/e.
         self.vector.reserve(CHUNK_SIZE);
+        // FIXME: decoding into uninit buffer?
         self.vector.resize(length + CHUNK_SIZE, 0u8);
 
         (&mut self.vector[length..], decoder)

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -225,6 +225,32 @@ impl Encoder {
         self.state.advance(inp, out)
     }
 
+    /// Encode a single chunk of data.
+    ///
+    /// This method will add an end marker to the encoded chunk.
+    ///
+    /// This is a convenience wrapper around [`into_vec`]. Use the `into_vec` adapter to customize
+    /// buffer size, to supply an existing vector, to control whether an end marker is required, or
+    /// to preserve partial data in the case of a decoding error.
+    ///
+    /// [`into_vec`]: #into_vec
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use weezl::{BitOrder, encode::Encoder};
+    ///
+    /// let data = b"Hello, world";
+    /// let encoded = Encoder::new(BitOrder::Msb, 9)
+    ///     .encode(data)
+    ///     .expect("All bytes valid for code size");
+    /// ```
+    pub fn encode(&mut self, data: &[u8]) -> Result<Vec<u8>, LzwError> {
+        let mut output = Vec::new();
+        self.into_vec(&mut output).encode_all(data).status?;
+        Ok(output)
+    }
+
     /// Construct a encoder into a writer.
     #[cfg(feature = "std")]
     pub fn into_stream<W: Write>(&mut self, writer: W) -> IntoStream<'_, W> {

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -297,7 +297,10 @@ impl Encoder {
     /// requires the `std`-feature. Also, it can make full use of the extra buffer control that the
     /// special target exposes.
     pub fn into_vec<'lt>(&'lt mut self, vec: &'lt mut Vec<u8>) -> IntoVec<'lt> {
-        IntoVec { encoder: self, vector: vec }
+        IntoVec {
+            encoder: self,
+            vector: vec,
+        }
     }
 
     /// Mark the encoding as in the process of finishing.
@@ -451,7 +454,7 @@ impl<'d, W: Write> IntoStream<'d, W> {
 
 impl IntoVec<'_> {
     /// Encode data from a slice.
-    pub fn encode(&mut self, read:  &[u8]) -> VectorResult {
+    pub fn encode(&mut self, read: &[u8]) -> VectorResult {
         self.encode_part(read, false)
     }
 

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -13,6 +13,22 @@ use std::io::{self, BufRead, Write};
 /// The same structure can be utilized with streams as well as your own buffers and driver logic.
 /// It may even be possible to mix them if you are sufficiently careful not to lose any written
 /// data in the process.
+///
+/// This is a sans-IO implementation, meaning that it only contains the state of the encoder and
+/// the caller will provide buffers for input and output data when calling the basic
+/// [`encode_bytes`] method. Nevertheless, a number of _adapters_ are provided in the `into_*`
+/// methods for enoding with a particular style of common IO.
+///
+/// * [`encode`] for encoding once without any IO-loop.
+/// * [`into_async`] for encoding with the `futures` traits for asynchronous IO.
+/// * [`into_stream`] for encoding with the standard `io` traits.
+/// * [`into_vec`] for in-memory encoding.
+///
+/// [`encode_bytes`]: #method.encode_bytes
+/// [`encode`]: #method.encode
+/// [`into_async`]: #method.into_async
+/// [`into_stream`]: #method.into_stream
+/// [`into_vec`]: #method.into_vec
 pub struct Encoder {
     /// Internally dispatch via a dynamic trait object. This did not have any significant
     /// performance impact as we batch data internally and this pointer does not change after

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,6 +9,17 @@ pub struct BufferResult {
     pub status: Result<LzwStatus, LzwError>,
 }
 
+/// The result of a coding operation into a vector.
+#[must_use = "Contains a status with potential error information"]
+pub struct VectorResult {
+    /// The number of bytes consumed from the input buffer.
+    pub consumed_in: usize,
+    /// The number of bytes written into the output buffer.
+    pub consumed_out: usize,
+    /// The status after returning from the write call.
+    pub status: Result<LzwStatus, LzwError>,
+}
+
 /// The result of coding into an output stream.
 #[cfg(feature = "std")]
 #[must_use = "Contains a status with potential error information"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,36 @@
 //! most or least significant bits first. The maximum possible code size is 12 bits, the smallest
 //! available code size is 2 bits.
 //!
+//! ## Example
+//!
+//! These two code blocks show the compression and corresponding decompression. Note that you must
+//! use the same arguments to `Encoder` and `Decoder`, otherwise the decoding might fail or produce
+//! bad results.
+//!
+#![cfg_attr(feature = "std", doc = "```")]
+#![cfg_attr(not(feature = "std"), doc = "```ignore")]
+//! use weezl::{BitOrder, encode::Encoder};
+//!
+//! let data = b"Hello, world";
+//! let compressed = Encoder::new(BitOrder::Msb, 9)
+//!     .encode(data)
+//!     .unwrap();
+//! ```
+//!
+#![cfg_attr(feature = "std", doc = "```")]
+#![cfg_attr(not(feature = "std"), doc = "```ignore")]
+//! use weezl::{BitOrder, decode::Decoder};
+//! # let compressed = b"\x80\x04\x81\x94l\x1b\x06\xf0\xb0 \x1d\xc6\xf1\xc8l\x19 \x10".to_vec();
+//! # let data = b"Hello, world";
+//!
+//! let decompressed = Decoder::new(BitOrder::Msb, 9)
+//!     .decode(&compressed)
+//!     .unwrap();
+//! assert_eq!(decompressed, data);
+//! ```
+//!
+//! ## LZW Details
+//!
 //! The de- and encoder expect the LZW stream to start with a clear code and end with an
 //! end code which are defined as follows:
 //!
@@ -17,19 +47,7 @@
 //! precise). Since there are no ways to handle allocation errors it is not recommended to operate
 //! it on 16-bit targets.
 //!
-//! Exemplary use of the encoder:
-//!
-#![cfg_attr(feature = "std", doc = "```")]
-#![cfg_attr(not(feature = "std"), doc = "```ignore")]
-//! use weezl::{BitOrder, encode::Encoder};
-//! let size = 8;
-//! let data = b"TOBEORNOTTOBEORTOBEORNOT";
-//! let mut compressed = vec![];
-//!
-//! let mut enc = Encoder::new(BitOrder::Msb, size);
-//! let result = enc.into_stream(&mut compressed).encode(&data[..]);
-//! result.status.unwrap();
-//! ```
+//! ## Allocations and standard library
 //!
 //! The main algorithm can be used in `no_std` as well, although it requires an allocator. This
 //! restriction might be lifted at a later stage. For this you should deactivate the `std` feature.

--- a/tests/roundtrip_vec.rs
+++ b/tests/roundtrip_vec.rs
@@ -1,0 +1,69 @@
+use std::{env, fs};
+use weezl::{decode, encode, BitOrder};
+
+#[derive(Clone, Copy, Debug)]
+enum Flavor {
+    Gif,
+    Tiff,
+}
+
+#[test]
+fn roundtrip_all() {
+    let file = env::args().next().unwrap();
+    let data = fs::read(file).unwrap();
+
+    for &flavor in &[Flavor::Gif, Flavor::Tiff] {
+        for &bit_order in &[BitOrder::Lsb, BitOrder::Msb] {
+            for bit_width in 2..8 {
+                let data: Vec<_> = data
+                    .iter()
+                    .copied()
+                    .map(|b| b & ((1 << bit_width) - 1))
+                    .collect();
+
+                println!("Roundtrip test {:?} {:?} {}", flavor, bit_order, bit_width);
+                assert_roundtrips(&*data, flavor, bit_width, bit_order);
+            }
+        }
+    }
+}
+
+fn assert_roundtrips(data: &[u8], flavor: Flavor, bit_width: u8, bit_order: BitOrder) {
+    let (c, d): (
+        fn(BitOrder, u8) -> encode::Encoder,
+        fn(BitOrder, u8) -> decode::Decoder,
+    ) = match flavor {
+        Flavor::Gif => (encode::Encoder::new, decode::Decoder::new),
+        Flavor::Tiff => (
+            encode::Encoder::with_tiff_size_switch,
+            decode::Decoder::with_tiff_size_switch,
+        ),
+    };
+    let mut encoder = c(bit_order, bit_width);
+    let mut buffer = Vec::with_capacity(2 * data.len() + 40);
+
+    let _ = encoder
+        .into_vec(&mut buffer)
+        .encode_all(data);
+
+    let mut decoder = d(bit_order, bit_width);
+    let mut compare = vec![];
+    let result = decoder
+        .into_vec(&mut compare)
+        .decode_all(buffer.as_slice());
+    assert!(
+        result.status.is_ok(),
+        "{:?}, {}, {:?}",
+        bit_order,
+        bit_width,
+        result.status
+    );
+    assert!(
+        data == &*compare,
+        "{:?}, {}\n{:?}\n{:?}",
+        bit_order,
+        bit_width,
+        data,
+        compare
+    );
+}

--- a/tests/roundtrip_vec.rs
+++ b/tests/roundtrip_vec.rs
@@ -42,15 +42,11 @@ fn assert_roundtrips(data: &[u8], flavor: Flavor, bit_width: u8, bit_order: BitO
     let mut encoder = c(bit_order, bit_width);
     let mut buffer = Vec::with_capacity(2 * data.len() + 40);
 
-    let _ = encoder
-        .into_vec(&mut buffer)
-        .encode_all(data);
+    let _ = encoder.into_vec(&mut buffer).encode_all(data);
 
     let mut decoder = d(bit_order, bit_width);
     let mut compare = vec![];
-    let result = decoder
-        .into_vec(&mut compare)
-        .decode_all(buffer.as_slice());
+    let result = decoder.into_vec(&mut compare).decode_all(buffer.as_slice());
     assert!(
         result.status.is_ok(),
         "{:?}, {}, {:?}",


### PR DESCRIPTION
Closes: #23 @s3bk

I don't like the idea of having a separate set of free standing methods due to the number of constructor arguments and the complications in terms of adding new constructors (e.g. a GNU compress compatible option). Instead, I chose an interface where the simplest in-memory case now looks like so:

```rust
let data = Decoder::new(BitOrder::Msb, 9).decode(compressed)?;
```

This adds some special treatment for vectors (which previously were handled via `io::Write` and `into_stream`) but on the other hand this will allow for forward compatible, slight performance gain if we add decoding/encoding into uninitialized buffers in the future. It also adds a useful adapter for the common `no_std, alloc` combination.