### PR TITLE
Add forbid(unsafe_code) to binary crate

### DIFF
--- a/bin/lzw.rs
+++ b/bin/lzw.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 use std::path::PathBuf;
 use std::{env, ffi, fs, io, process};
 


### PR DESCRIPTION
This makes cargo-geiger mark this crate better. See
https://github.com/rust-secure-code/cargo-geiger/issues/81

It changes the cargo geiger symbol from the red question mark to the lock icon:

<img width="608" alt="Screenshot 2021-08-23 at 14 08 47" src="https://user-images.githubusercontent.com/85933475/130444596-c39d990d-828a-4efc-b8d5-847a76ed35cd.png">
