### PR TITLE
Check for overflow of `next_code` when adding `burst_size`

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -762,9 +762,13 @@ impl<C: CodeBuffer> Stateful for DecodeState<C> {
                 }
 
                 // Check that we don't overflow the code size with all codes we burst decode.
-                let potential_code = self.next_code + burst_size as u16;
-                burst_size += 1;
-                if potential_code == self.code_buffer.max_code() - Code::from(self.is_tiff) {
+                if let Some(potential_code) = self.next_code.checked_add(burst_size as u16) {
+                    burst_size += 1;
+                    if potential_code == self.code_buffer.max_code() - Code::from(self.is_tiff) {
+                        break;
+                    }
+                } else {
+                    // next_code overflowed
                     break;
                 }
 


### PR DESCRIPTION
This addresses a problem in the GIF parser detected during fuzzing of a crate that utilizes `image-rs`.  The issue can be reproduced using this short test program and the attached file (too large to include in the source -- unzip first).
``` rust
const BAD_GIF: &[u8] = include_bytes!(concat!(
    env!("CARGO_MANIFEST_DIR"),
    "/5220731288420352.gif"
));

fn main() {
    if let Err(e) = image::load_from_memory(BAD_GIF) {
        eprintln!("failed to load: {e}");
    }
}
```
[5220731288420352.gif.zip](https://github.com/image-rs/lzw/files/8514918/5220731288420352.gif.zip)

After the fix, loading the malformed image produces a usable `Err` result:
```
Format error decoding Gif: unexpected EOF
```
