### PR TITLE
Fix stale next_code in reset()

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -595,6 +595,7 @@ impl<C: CodeBuffer> Stateful for DecodeState<C> {
 
     fn reset(&mut self) {
         self.table.init(self.min_size);
+        self.next_code = (1 << self.min_size) + 2;
         self.buffer.read_mark = 0;
         self.buffer.write_mark = 0;
         self.last = None;


### PR DESCRIPTION
Leftover state leads to a panic in:

```rust
let len = self.table.depths[usize::from(*b)];
```