### PR TITLE
crates.io release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -658,7 +658,7 @@ dependencies = [
 
 [[package]]
 name = "weezl"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "criterion 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.21 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weezl"
-version = "0.1.7"
+version = "0.1.8"
 license = "MIT OR Apache-2.0"
 description = "Fast LZW compression and decompression."
 authors = ["The image-rs Developers"]

--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,8 @@
+## Version 0.1.8
+
+- Fixed incorrect state after `Decoder::reset`
+- Added `Debug` to result types
+
 ## Version 0.1.7
 
 - Implicit reset is now supported for decoding.


### PR DESCRIPTION
This is the only issue I've found testing gif 0.13, so once that is released, gif will be ready too.