### PR TITLE
Support tiff's implicit end-of-stream decoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,5 +82,9 @@ required-features = ["alloc"]
 name = "implicit_reset"
 required-features = ["std"]
 
+[[test]]
+name = "end_of_buffer"
+required-features = ["alloc"]
+
 [package.metadata.docs.rs]
 all-features = true

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -827,15 +827,13 @@ impl<C: CodeBuffer, CgC: CodegenConstants> Stateful for DecodeState<C, CgC> {
         let mut last_decoded: Option<&[u8]> = None;
 
         while let Some((mut code, mut link)) = code_link.take() {
-            let want_more_space = if CgC::YIELD_ON_FULL {
-                out.is_empty()
-            } else {
+            let want_more_space = {
                 // We have more data buffered but not enough space to put it? We want fetch a next
                 // symbol if possible as in the case of it being a new symbol we can refer to the
                 // buffered output as the source for that symbol's meaning and do a memcpy. It
                 // would be correct to break here instead but then that symbol must be
                 // reconstructed by iterating the code table.
-                out.is_empty() && !self.buffer.buffer().is_empty()
+                out.is_empty()
             };
 
             if want_more_space {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -202,11 +202,14 @@ impl Configuration {
 
     /// Immediately yield to the caller when the decoder buffer is full.
     ///
-    /// This can be used when dealing with "relaxed" stream interpretation that may not contain an
-    /// explicit EOF but instead expect the decoder to stop fetching symbols when some out-of-band
-    /// specified length of the decoded text has been reached. Symbols afterwards can not be
-    /// expected to be valid. The decoder will yield to the caller instead of returning an error by
-    /// interpreting the following bit-stream.
+    /// This can be used for `libtiff` compatibility. It will use a "relaxed" stream interpretation
+    /// that need not contain an explicit EOF. Instead, the decoder is expected to stop fetching
+    /// symbols when some out-of-band specified length of the decoded text has been reached. The
+    /// caller indicates this maximum length through the available output buffer space.
+    ///
+    /// Symbols afterwards must not be expected to be valid. On filling the output buffer space
+    /// completely, the decoder will return immediately to the caller instead of potentially
+    /// interpreting the following bit-stream (and returning an error on doing so).
     ///
     /// Default: `false`.
     pub fn with_yield_on_full_buffer(self, do_yield: bool) -> Self {

--- a/tests/end_of_buffer.rs
+++ b/tests/end_of_buffer.rs
@@ -1,0 +1,10 @@
+use weezl::{decode, BitOrder};
+
+#[test]
+fn stop_after_end_of_buffer() {
+    let inp = vec![0x00u8, 0x01, 0x02, 0xff];
+    let mut decoder = decode::Decoder::new(BitOrder::Lsb, 7);
+    let mut out = vec![0u8, 0u8, 0u8];
+    let status = decoder.decode_bytes(&inp, &mut out).status;
+    assert!(status.is_ok(), "{:?} {:?}", status, out);
+}

--- a/tests/end_of_buffer.rs
+++ b/tests/end_of_buffer.rs
@@ -3,7 +3,9 @@ use weezl::{decode, BitOrder};
 #[test]
 fn stop_after_end_of_buffer() {
     let inp = vec![0x00u8, 0x01, 0x02, 0xff];
-    let mut decoder = decode::Decoder::new(BitOrder::Lsb, 7);
+    let mut decoder = decode::Configuration::new(BitOrder::Lsb, 7)
+        .with_yield_on_full_buffer(true)
+        .build();
     let mut out = vec![0u8, 0u8, 0u8];
     let status = decoder.decode_bytes(&inp, &mut out).status;
     assert!(status.is_ok(), "{:?} {:?}", status, out);


### PR DESCRIPTION
This is compiled into a separate function, a new trait impl via dynamic
dispatch. This is minimally invasive to the performance of the previous
code where it should be constant-folded away. As an aide a new `Configuration` type ensures the construction can be done in a builder style pattern to compose. This is mirrored to the encoder for consistency.