### PR TITLE
Performance tuning

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1004,9 +1004,10 @@ impl<C: CodeBuffer, CgC: CodegenConstants> Stateful for DecodeState<C, CgC> {
                         Some(last) => last,
                         None => &self.buffer.bytes[..self.buffer.write_mark],
                     };
-                    cha = source[0];
+
+                    cha = source.get(0).map(|x| *x).unwrap_or(0);
                     target[..source.len()].copy_from_slice(source);
-                    target[source.len()..][0] = source[0];
+                    target[source.len()..][0] = cha;
                 } else {
                     cha = self.table.reconstruct(new_code, target);
                 }


### PR DESCRIPTION
Multiple performance patches.

We had this concept of 'bursts' introduced a while ago. That is a sequence of consecutive codes that are *not* dependent on each other, i.e. none of them leads to an increase in code size, none are control codes, all decoded codes have been created in previous iterations of the decoding loop, and the output buffer allows all their decoding to be written in an existing slice. The point of this definition is to ensure that certain loops occurring within have as little data dependency as possible. Previously, we did not reap the rewards of this as effectively as here.

This patch is best read commit-per-commit.

- The bit-buffer now decodes multiple codes without having to adjust its own count. This avoids a few masking operations and other bookkeeping per loop. While in theory some of them are wasted, we hit control codes only rarely in practice.
- The state we stored to keep track of the prior code word had some redundant data. We do not need the whole linked list entry associated with that code.
- We now keep track of the _first_ byte of each code in addition to the last. This ensures that reading the first byte has no data dependency on the linked-list iteration loop. The compiler does better things with this, we no longer read from the output slice when we fill it and we no longer need the compiler to deduce it can not be empty (which it didn't).
- When we create the linked-list entries for all codes created from reading a code word, we now use separate loops for all different kinds of state (decoded data, depth, link) instead of one loop. In particular the link loop no longer has fewer indirect data dependencies through the link vector that is being modified.

Overall (Ryzen 9 7900X)

```
msb-8/benches/Cargo-8-msb.lzw/8687
                        time:   [40.383 µs 40.440 µs 40.507 µs]
                        thrpt:  [617.87 MiB/s 618.90 MiB/s 619.78 MiB/s]
                 change:
                        time:   [-11.145% -11.051% -10.951%] (p = 0.00 < 0.05)
                        thrpt:  [+12.297% +12.424% +12.543%]
                        Performance has improved.

msb-8/benches/binary-8-msb.lzw/1428141
                        time:   [9.5365 ms 9.5390 ms 9.5416 ms]
                        thrpt:  [305.59 MiB/s 305.67 MiB/s 305.75 MiB/s]
                 change:
                        time:   [-2.9047% -2.8740% -2.8409%] (p = 0.00 < 0.05)
                        thrpt:  [+2.9239% +2.9591% +2.9916%]
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  9 (9.00%) high mild
  3 (3.00%) high severe

msb-8/benches/lib-8-msb.lzw/731
                        time:   [3.1133 µs 3.1145 µs 3.1157 µs]
                        thrpt:  [342.51 MiB/s 342.64 MiB/s 342.78 MiB/s]
                 change:
                        time:   [-17.801% -17.755% -17.713%] (p = 0.00 < 0.05)
                        thrpt:  [+21.526% +21.589% +21.656%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
```

In other words, this would be once again the fastest Rust lzw library by a margin. Please add your own performance numbers. I've also noted we may want to extend the test suite as there are no Lsb numbers here.