### PR TITLE
Release notes for 0.1.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -658,7 +658,7 @@ dependencies = [
 
 [[package]]
 name = "weezl"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "criterion 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.21 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weezl"
-version = "0.1.9"
+version = "0.1.10"
 license = "MIT OR Apache-2.0"
 description = "Fast LZW compression and decompression."
 authors = ["The image-rs Developers"]

--- a/Changes.md
+++ b/Changes.md
@@ -1,4 +1,11 @@
-## Version 0.1.9
+## Version 0.1.10
+
+- Reverted changes made in 0.1.9 to the behavior of the decoder under non
+  libtiff-compatibility mode. Trying to read the decoder with an empty output
+  buffer will at least inspect the next symbol and either error or indicate the
+  end-of-stream accordingly.
+
+## Version 0.1.9 (yanked)
 
 - Increased decoding throughput by 3—30% depending on CPU and data.
 - Added `{encode,decode}::Configuration` as builder types for their respective


### PR DESCRIPTION
Let's try this again. I've ran the gif, tiff, and lopdf test suites on the tip of this branch.