### PR TITLE
Release notes for 0.1.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weezl"
-version = "0.1.10"
+version = "0.1.11"
 license = "MIT OR Apache-2.0"
 description = "Fast LZW compression and decompression."
 authors = ["The image-rs Developers"]

--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,9 @@
+## Version 0.1.11
+
+- Adjusted a debug assertion that handled 1-bit code sizes incorrectly in the
+  decoder (relevant for TIFF but non-standard for GIF). In that case the size
+  switch semantics are a bit messy.
+
 ## Version 0.1.10
 
 - Reverted changes made in 0.1.9 to the behavior of the decoder under non


### PR DESCRIPTION
It seems that the fix to the debug assertion did not make it into a release yet, and we are hitting it in the latest test suite for `tiff`.