### PR TITLE
Fixup 1-bit GIF code size bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,5 +102,9 @@ required-features = ["alloc"]
 name = "progress_into_buffer"
 required-features = ["alloc"]
 
+[[test]]
+name = "regression_gif"
+required-features = ["alloc"]
+
 [package.metadata.docs.rs]
 all-features = true

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -834,13 +834,9 @@ impl<C: CodeBuffer, CgC: CodegenConstants> Stateful for DecodeState<C, CgC> {
             None => {
                 match self.next_symbol(&mut inp) {
                     // Plainly invalid code.
-                    Some(code) if code > self.next_code => {
-                        status = Err(LzwError::InvalidCode)
-                    }
+                    Some(code) if code > self.next_code => status = Err(LzwError::InvalidCode),
                     // next_code would require an actual predecessor.
-                    Some(code) if code == self.next_code => {
-                        status = Err(LzwError::InvalidCode)
-                    }
+                    Some(code) if code == self.next_code => status = Err(LzwError::InvalidCode),
                     // No more symbols available and nothing decoded yet.
                     // Assume that we didn't make progress, this may get reset to Done if we read
                     // some bytes from the input.

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -668,45 +668,75 @@ mod impl_decode_into_async;
 
 impl<C: CodeBuffer, CgC: CodegenConstants> DecodeState<C, CgC> {
     fn new(min_size: u8) -> Self {
-        let mut code_buffer = C::new(min_size);
-        let next_code: u16 = (1 << min_size) + 2;
-        // At min_size 0 or 1 the clear+end codes already fill max_code,
-        // so bump code_size once so the first code can be read. No-op
-        // for min_size >= 2.
-        if next_code > code_buffer.max_code() && code_buffer.code_size() < MAX_CODESIZE {
-            code_buffer.bump_code_size();
-        }
-        DecodeState {
+        let mut pre_state = DecodeState {
             min_size,
             table: Table::new(),
             buffer: Buffer::new(),
             last: None,
             clear_code: 1 << min_size,
             end_code: (1 << min_size) + 1,
-            next_code,
+            next_code: (1 << min_size) + 2,
             has_ended: false,
             is_tiff: false,
             implicit_reset: true,
-            code_buffer,
+            code_buffer: C::new(min_size),
             constants: core::marker::PhantomData,
-        }
+        };
+
+        pre_state.bump_initial_code_size();
+        pre_state
     }
 
     fn init_tables(&mut self) {
         self.code_buffer.reset(self.min_size);
         self.next_code = (1 << self.min_size) + 2;
         self.table.init(self.min_size);
-        if self.next_code > self.code_buffer.max_code()
-            && self.code_buffer.code_size() < MAX_CODESIZE
-        {
-            self.code_buffer.bump_code_size();
-        }
+        self.bump_initial_code_size();
     }
 
     fn reset_tables(&mut self) {
         self.code_buffer.reset(self.min_size);
         self.next_code = (1 << self.min_size) + 2;
         self.table.clear(self.min_size);
+        self.bump_initial_code_size();
+    }
+
+    /// Bump the code size before any symbol is read.
+    fn bump_initial_code_size(&mut self) {
+        // For 0-bit codes:
+        //
+        // 0 - 0b
+        // 1 - clear
+        // 2 - end
+        // (3) - next
+        //
+        // Here it is clear that end could not be coded without bumping the size.
+        //
+        // For 1-bit codes:
+        //
+        // 0 - 0b0
+        // 1 - 0b1
+        // 2 - clear
+        // 3 - end
+        // (4) - next
+        //
+        // Note that the `next` is entirely fictional and not valid as the first code in any case.
+        // We have, in particular, a sample for GIF for 1-bit codes that requires the first symbol
+        // to be read with a 2-bit word size as the bit stream is `0b110010`, i.e. there is an
+        // end code immediately after a clear code and both must be interpreted accordingly.
+        //
+        // However for TIFF the size switch is always one earlier, so compensate even though
+        // realistically you should not use this combination: tiff mandates 8 bits.
+        if self.end_code > self.code_buffer.max_code() - Code::from(self.is_tiff)
+            && self.code_buffer.code_size() < MAX_CODESIZE
+        {
+            self.code_buffer.bump_code_size();
+        }
+    }
+
+    /// Bump the code size after the first coded symbol is read, ensure the `next_code` can be coded
+    /// in all cases.
+    fn bump_post_initial_code_size(&mut self) {
         if self.next_code > self.code_buffer.max_code()
             && self.code_buffer.code_size() < MAX_CODESIZE
         {
@@ -804,9 +834,13 @@ impl<C: CodeBuffer, CgC: CodegenConstants> Stateful for DecodeState<C, CgC> {
             None => {
                 match self.next_symbol(&mut inp) {
                     // Plainly invalid code.
-                    Some(code) if code > self.next_code => status = Err(LzwError::InvalidCode),
+                    Some(code) if code > self.next_code => {
+                        status = Err(LzwError::InvalidCode)
+                    }
                     // next_code would require an actual predecessor.
-                    Some(code) if code == self.next_code => status = Err(LzwError::InvalidCode),
+                    Some(code) if code == self.next_code => {
+                        status = Err(LzwError::InvalidCode)
+                    }
                     // No more symbols available and nothing decoded yet.
                     // Assume that we didn't make progress, this may get reset to Done if we read
                     // some bytes from the input.
@@ -830,6 +864,7 @@ impl<C: CodeBuffer, CgC: CodegenConstants> Stateful for DecodeState<C, CgC> {
                                 // Reconstruct the first code in the buffer if this wasn't supposed
                                 // to be treated as a fatal error.
                                 self.buffer.fill_reconstruct(&self.table, init_code);
+                                self.bump_post_initial_code_size();
                                 code_link = Some(DerivationBase {
                                     code: init_code,
                                     first: self.table.first_of(init_code),

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -601,18 +601,27 @@ impl<B: Buffer> EncodeState<B> {
             clear_code,
             buffer: B::new(min_size),
         };
-        // At min_size 0 or 1 the alphabet plus clear/end codes already
-        // exhaust (or exceed) the starting max_code, so the initial clear
-        // must be emitted at a bumped code size. A single bump is always
-        // sufficient (see bump_if_lowbit in decode.rs for the proof).
-        // Normal-size (>= 2) streams fall straight through.
-        if state.tree.keys.len() > usize::from(state.buffer.max_code())
-            && state.buffer.code_size() < MAX_CODESIZE
-        {
-            state.buffer.bump_code_size();
-        }
+
+        state.bump_initial_code_size();
         state.buffer_code(clear_code);
         state
+    }
+
+    /// Initialize rather odd stream sizes.
+    fn bump_initial_code_size(&mut self) {
+        // At min_size 0 the alphabet plus clear/end codes already exhaust (or exceed) the starting
+        // max_code, so the initial clear must be emitted at a bumped code size. At min_size 1 the
+        // special symbols can be coded but the next-code could not, however see `decode.rs` and
+        // `regression_gif` for a specimen that in non-TIFF logic this is expected.
+        //
+        // A single bump is always sufficient (see bump_if_lowbit in decode.rs for the proof).
+        //
+        // Normal-size (>= 2) streams fall straight through.
+        if self.clear_code >= self.buffer.max_code() - Code::from(self.is_tiff)
+            && self.buffer.code_size() < MAX_CODESIZE
+        {
+            self.buffer.bump_code_size();
+        }
     }
 }
 

--- a/tests/regression_gif.rs
+++ b/tests/regression_gif.rs
@@ -12,8 +12,7 @@ fn regression_gif_97() {
     // symbol 110 that is even greater than the next-code.
     let data = &[0x32];
 
-    let mut decoder = decode::Configuration::new(BitOrder::Lsb, 1)
-        .build();
+    let mut decoder = decode::Configuration::new(BitOrder::Lsb, 1).build();
 
     let mut output = vec![];
     let result = decoder.into_vec(&mut output).decode_all(data);
@@ -24,8 +23,7 @@ fn regression_gif_97() {
 
 #[test]
 fn encoder_roundtrip() {
-    let mut encoder = encode::Configuration::new(BitOrder::Lsb, 1)
-        .build();
+    let mut encoder = encode::Configuration::new(BitOrder::Lsb, 1).build();
 
     let mut output = vec![];
     let result = encoder.into_vec(&mut output).encode_all(&[0]);

--- a/tests/regression_gif.rs
+++ b/tests/regression_gif.rs
@@ -1,4 +1,4 @@
-use weezl::{decode, BitOrder};
+use weezl::{decode, encode, BitOrder};
 
 /// See:https://github.com/image-rs/image-gif/issues/97
 #[test]
@@ -20,4 +20,17 @@ fn regression_gif_97() {
     assert!(matches!(result.status, Ok(weezl::LzwStatus::Ok)));
     assert_eq!(result.consumed_in, 1);
     assert_eq!(output, &[0]);
+}
+
+#[test]
+fn encoder_roundtrip() {
+    let mut encoder = encode::Configuration::new(BitOrder::Lsb, 1)
+        .build();
+
+    let mut output = vec![];
+    let result = encoder.into_vec(&mut output).encode_all(&[0]);
+
+    assert!(matches!(result.status, Ok(weezl::LzwStatus::Ok)));
+    assert_eq!(result.consumed_in, 1);
+    assert_eq!(output, &[0x32]);
 }

--- a/tests/regression_gif.rs
+++ b/tests/regression_gif.rs
@@ -1,0 +1,23 @@
+use weezl::{decode, BitOrder};
+
+/// See:https://github.com/image-rs/image-gif/issues/97
+#[test]
+fn regression_gif_97() {
+    // The data stream contains three symbols, in bits: 10, 00, (0)11
+    // That is the interpretation must be: clear, (0), end
+    // It is ambiguous if the end symbol is coded as 2 or 3 bits but in order to be able to code a
+    // next code we assume a size switch. However, the first data symbol _must_ be coded as 2 bits
+    // otherwise it would code 100 which invalidly codes the next-code before any derivation.
+    // Similarly, if we always assumed 3 bits then it would be (011) (110), coding the invalid
+    // symbol 110 that is even greater than the next-code.
+    let data = &[0x32];
+
+    let mut decoder = decode::Configuration::new(BitOrder::Lsb, 1)
+        .build();
+
+    let mut output = vec![];
+    let result = decoder.into_vec(&mut output).decode_all(data);
+    assert!(matches!(result.status, Ok(weezl::LzwStatus::Ok)));
+    assert_eq!(result.consumed_in, 1);
+    assert_eq!(output, &[0]);
+}


### PR DESCRIPTION
@lilith FYI, in GIF we had a specimen contradicting the early bump in #67. While both are valid, only 0-bit codes _require_ the very eager early bump. For 1-bit codes it suffices if the bump occurs after the first symbol with the usual logic; except TIFF logic would assume it to have happened a symbol earlier so this implementation is now based around the difference.

Original specimen here, https://github.com/image-rs/image-gif/issues/97, from servo and rediscovered while checking against `gif`. Now with a regression test that was missing.